### PR TITLE
Ruby 2.0 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,5 +5,7 @@ AllCops:
     - example.rb
 Metrics/AbcSize:
   Enabled: false
+Metrics/LineLength:
+  Max: 100
 Style/SpecialGlobalVars:
   Enabled: false

--- a/lib/vcoworkflows.rb
+++ b/lib/vcoworkflows.rb
@@ -11,8 +11,6 @@ require File.dirname(__FILE__) + '/vcoworkflows/workflowtoken'
 require File.dirname(__FILE__) + '/vcoworkflows/cli/execute'
 require File.dirname(__FILE__) + '/vcoworkflows/cli/query'
 
-# rubocop:disable LineLength
-
 # Refer to README.md for use instructions
 module VcoWorkflows
   # Start of main CLI processing

--- a/lib/vcoworkflows/cli/execute.rb
+++ b/lib/vcoworkflows/cli/execute.rb
@@ -1,7 +1,7 @@
 require 'vcoworkflows'
 require 'thor/group'
 
-# rubocop:disable MethodLength, LineLength
+# rubocop:disable MethodLength
 
 # VcoWorkflows
 module VcoWorkflows

--- a/lib/vcoworkflows/config.rb
+++ b/lib/vcoworkflows/config.rb
@@ -17,7 +17,7 @@ module VcoWorkflows
     # Whether or not to do SSL/TLS Certificate verification
     attr_accessor :verify_ssl
 
-    # rubocop:disable LineLength, MethodLength, CyclomaticComplexity, PerceivedComplexity
+    # rubocop:disable MethodLength, CyclomaticComplexity, PerceivedComplexity
 
     # Constructor
     # @param [String] config_file Path to config file to load
@@ -48,8 +48,6 @@ module VcoWorkflows
       fail(IOError, ERR[:password_unset]) if @password.nil?
     end
     # rubocop:enable LineLength, MethodLength, CyclomaticComplexity, PerceivedComplexity
-
-    # rubocop:disable LineLength
 
     # Set the URL for the vCO server, force the path component.
     # @param [String] vco_url

--- a/lib/vcoworkflows/vcosession.rb
+++ b/lib/vcoworkflows/vcosession.rb
@@ -10,7 +10,7 @@ module VcoWorkflows
     # Accessor for rest-client object, primarily for testing purposes
     attr_reader :rest_resource
 
-    # rubocop:disable MethodLength, LineLength
+    # rubocop:disable MethodLength
 
     # Initialize the session
     #

--- a/lib/vcoworkflows/workflow.rb
+++ b/lib/vcoworkflows/workflow.rb
@@ -316,14 +316,6 @@ module VcoWorkflows
 
     # rubocop:disable LineLength
 
-    # Verify that all mandatory input parameters have values
-    private def verify_parameters
-      required_parameters.each do |name, wfparam|
-        if wfparam.required? && (wfparam.value.nil? || wfparam.value.size == 0)
-          fail(IOError, ERR[:param_verify_failed] << "#{name} required but not present.")
-        end
-      end
-    end
     # rubocop:enable LineLength
 
     # rubocop:disable LineLength
@@ -393,13 +385,24 @@ module VcoWorkflows
     end
     # rubocop:enable MethodLength
 
+    private
+
     # Convert the input parameters to a JSON document
     # @return [String]
-    private def input_parameter_json
+    def input_parameter_json
       tmp_params = []
       @input_parameters.each_value { |v| tmp_params << v.as_struct if v.set? }
       param_struct = { parameters: tmp_params }
       param_struct.to_json
+    end
+
+    # Verify that all mandatory input parameters have values
+    def verify_parameters
+      required_parameters.each do |name, wfparam|
+        if wfparam.required? && (wfparam.value.nil? || wfparam.value.size == 0)
+          fail(IOError, ERR[:param_verify_failed] << "#{name} required but not present.") # rubocop:disable Metrics/LineLength
+        end
+      end
     end
   end
   # rubocop:enable ClassLength

--- a/lib/vcoworkflows/workflow.rb
+++ b/lib/vcoworkflows/workflow.rb
@@ -11,8 +11,6 @@ module VcoWorkflows
 
   # Class to represent a Workflow as presented by vCenter Orchestrator.
   class Workflow
-    # rubocop:disable LineLength
-
     # Workflow GUID
     # @return [String] workflow GUID
     attr_reader :id
@@ -49,9 +47,7 @@ module VcoWorkflows
     # @return [String]
     attr_reader :source_json
 
-    # rubocop:enable LineLength
-
-    # rubocop:disable CyclomaticComplexity, PerceivedComplexity, MethodLength, LineLength
+    # rubocop:disable CyclomaticComplexity, PerceivedComplexity, MethodLength
 
     # Create a Workflow object given vCenter Orchestrator's JSON description
     #
@@ -221,9 +217,7 @@ module VcoWorkflows
       end
       wfparams
     end
-    # rubocop:enable MethodLength, LineLength
-
-    # rubocop:disable LineLength
+    # rubocop:enable MethodLength
 
     # Process exceptions raised in parse_parameters by bravely ignoring them
     #   and forging ahead blindly!
@@ -235,9 +229,6 @@ module VcoWorkflows
       $stderr.puts error.message
       $stderr.puts "\nBravely forging on and ignoring parameter #{wfparam.name}!"
     end
-    # rubocop:enable LineLength
-
-    # rubocop:disable LineLength
 
     # Get an array of the names of all the required input parameters
     # @return [Hash] Hash of WorkflowParameter input parameters which
@@ -247,9 +238,6 @@ module VcoWorkflows
       @input_parameters.each_value { |v| required[v.name] = v if v.required? }
       required
     end
-    # rubocop:enable LineLength
-
-    # rubocop:disable LineLength, MethodLength
 
     # Get the parameter object named. If a value is provided, set the value
     # and return the parameter object.
@@ -271,7 +259,7 @@ module VcoWorkflows
       end unless parameter_value.nil?
       @input_parameters[parameter_name]
     end
-    # rubocop:enable LineLength, MethodLength
+    # rubocop:enable MethodLength
 
     # Set a parameter with a WorkflowParameter object
     # @param [VcoWorkflows::WorkflowParameter] wfparameter New parameter
@@ -293,8 +281,6 @@ module VcoWorkflows
       parameter_hash.each { |name, value| parameter(name, value) }
     end
 
-    # rubocop:disable LineLength
-
     # Set a parameter to a value.
     # @deprecated Use {#parameter} instead
     # @param [String] parameter_name name of the parameter to set
@@ -314,12 +300,6 @@ module VcoWorkflows
       parameter(parameter_name).value
     end
 
-    # rubocop:disable LineLength
-
-    # rubocop:enable LineLength
-
-    # rubocop:disable LineLength
-
     # Execute this workflow
     # @param [VcoWorkflows::WorkflowService] workflow_service
     # @return [String] Workflow Execution ID
@@ -334,7 +314,6 @@ module VcoWorkflows
       # Let's get this thing running!
       @execution_id = workflow_service.execute_workflow(@id, input_parameter_json)
     end
-    # rubocop:enable LineLength
 
     # Get a list of all the executions of this workflow. Wrapper for
     # VcoWorkflows::WorkflowService#get_execution_list

--- a/lib/vcoworkflows/workflowparameter.rb
+++ b/lib/vcoworkflows/workflowparameter.rb
@@ -58,8 +58,6 @@ module VcoWorkflows
     end
     # rubocop:enable MethodLength
 
-    # rubocop:disable CyclomaticComplexity
-
     # Set the parameter value
     # @param [Object] value Value for the parameter
     def set(value)
@@ -84,7 +82,6 @@ module VcoWorkflows
     end
 
     # rubocop:disable TrivialAccessors
-    # rubocop:disable LineLength
 
     # Set whether or not this WorkflowParameter is required
     # @param [Boolean] required Set this parameter as required (if not specified)

--- a/lib/vcoworkflows/workflowpresentation.rb
+++ b/lib/vcoworkflows/workflowpresentation.rb
@@ -7,8 +7,6 @@ require 'json'
 
 # VcoWorkflows
 module VcoWorkflows
-  # rubocop:disable ClassLength
-
   # WorkflowPresentation is a helper class for Workflow and is primarily used
   # internally to apply additional constraints to WorkflowParameters. Currently
   # WorkflowPresentation examines the presentation JSON from vCO to determine
@@ -22,7 +20,7 @@ module VcoWorkflows
     # @return [String[]] Array of strings (names of parameters)
     attr_reader :required
 
-    # rubocop:disable LineLength, MethodLength
+    # rubocop:disable MethodLength
 
     # Create a new WorkflowPresentation
     # @param [VcoWorkflows::WorkflowService] workflow_service workflow service to use

--- a/lib/vcoworkflows/workflowservice.rb
+++ b/lib/vcoworkflows/workflowservice.rb
@@ -15,8 +15,6 @@ module VcoWorkflows
     # @return [VcoWorkflows::VcoSession]
     attr_reader :session
 
-    # rubocop:disable LineLength
-
     # Create a new WorkflowService
     # @param [VcoWorkflows::VcoSession] session Session object for the API endpoint
     # @return [VcoWorkflows::WorkflowService]
@@ -105,9 +103,7 @@ module VcoWorkflows
       response = @session.post(path, parameter_json)
       # Execution ID is the final component in the Location header URL, so
       # chop off the front, then pull off any trailing /
-      # rubocop:disable LineLength
       response.headers[:location].gsub(%r{^.*/executions/}, '').gsub(%r{\/$}, '')
-      # rubocop:enable LineLength
     end
   end
 end

--- a/spec/vcoworkflows/config_spec.rb
+++ b/spec/vcoworkflows/config_spec.rb
@@ -1,8 +1,6 @@
 require_relative '../spec_helper.rb'
 require 'vcoworkflows'
 
-# rubocop:disable LineLength
-
 describe VcoWorkflows::Config, 'Config' do
   before(:each) do
     @url = 'https://vcoserver.example.com:8281/vco/api'

--- a/spec/vcoworkflows/vcosession_spec.rb
+++ b/spec/vcoworkflows/vcosession_spec.rb
@@ -1,8 +1,6 @@
 require_relative '../spec_helper.rb'
 require 'vcoworkflows'
 
-# rubocop:disable LineLength
-
 describe VcoWorkflows::VcoSession, 'VcoSession' do
   before(:each) do
     @uri = 'https://vcoserver.example.com:8281'


### PR DESCRIPTION
Two methods in workflow.rb used the new Ruby >= 2.1 syntax
of prefixing the `def` with `private` to indicate it is a
private method. However, the gemspec supports Ruby 2.0 where
this syntax is not supported. This change uses the old-style
syntax in order to support Ruby 2.0.

I also addressed some rubocop failures and cleanliness issues.

Thanks for taking the time to look at this PR!