### PR TITLE
Fix parse_failure method in workflows.rb

### DIFF
--- a/lib/vcoworkflows/workflow.rb
+++ b/lib/vcoworkflows/workflow.rb
@@ -201,13 +201,13 @@ module VcoWorkflows
                 value << element[element.keys.first]['value']
               end
             rescue StandardError => error
-              parse_failure(error)
+              parse_failure(error, wfparam, parameter)
             end
           else
             begin
               value = parameter['value'][parameter['value'].keys.first]['value']
             rescue StandardError => error
-              parse_failure(error)
+              parse_failure(error, wfparam, parameter)
             end
           end
           value = nil if value.eql?('null')
@@ -222,7 +222,7 @@ module VcoWorkflows
     # Process exceptions raised in parse_parameters by bravely ignoring them
     #   and forging ahead blindly!
     # @param [Exception] error
-    def self.parse_failure(error)
+    def self.parse_failure(error, wfparam, parameter)
       $stderr.puts "\nWhoops!"
       $stderr.puts "Ran into a problem parsing parameter #{wfparam.name} (#{wfparam.type})!"
       $stderr.puts "Source data: #{JSON.pretty_generate(parameter)}\n"


### PR DESCRIPTION
If workflows.rb encounters a problem parsing a parameter -- e.g., if
an element is nil -- it will call the parse_failure method. That
method tries to print out the values of the "wfparam" and "parameter"
Ruby variables. But it fails because those variables are not passed in
to that method (and are out of scope). So Test Kitchen exits with this
cryptic error:

  Failed to complete #create action: [undefined local variable or
  method `wfparam' for VcoWorkflows::Workflow:Class]

This PR simply passes those variables in to the parse_failure method
so it can display those values.